### PR TITLE
Bump holidays dependency to 0.99

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install pytest holidays==0.94
+          pip install pytest holidays==0.99
 
       - name: Run tests
         run: pytest tests/ -v

--- a/custom_components/isitpayday/__init__.py
+++ b/custom_components/isitpayday/__init__.py
@@ -7,21 +7,21 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.util import dt as dt_util
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
-    DOMAIN,
-    CONF_NAME,
-    CONF_COUNTRY,
-    CONF_PAY_FREQ,
-    CONF_PAY_DAY,
-    CONF_LAST_PAY_DATE,
-    CONF_WEEKDAY,
     CONF_BANK_OFFSET,
-    CONF_SUBDIV,
+    CONF_COUNTRY,
     CONF_EVENT_TIME,
+    CONF_LAST_PAY_DATE,
+    CONF_NAME,
+    CONF_PAY_DAY,
+    CONF_PAY_FREQ,
+    CONF_SUBDIV,
+    CONF_WEEKDAY,
     DEFAULT_EVENT_TIME,
+    DOMAIN,
     EVENT_PAYDAY,
 )
 from .payday_calculator import (
@@ -259,7 +259,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     def _on_payday(now) -> None:
         _payday_event_unsubs.pop(entry.entry_id, None)
         payday = coordinator.data.get("payday_next") if coordinator.data else None
-        if isinstance(payday, date) and _payday_last_fired.get(entry.entry_id) != payday:
+        if (
+            isinstance(payday, date)
+            and _payday_last_fired.get(entry.entry_id) != payday
+        ):
             _payday_last_fired[entry.entry_id] = payday
             _fire_payday_event(hass, entry, instance_name, payday)
         # Refresh so the coordinator advances to the following payday,

--- a/custom_components/isitpayday/binary_sensor.py
+++ b/custom_components/isitpayday/binary_sensor.py
@@ -9,11 +9,11 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     CONF_CONFIG_URL,
-    DOMAIN,
     CONF_MANUFACTURER,
     CONF_MODEL,
-    ICON_IS_IT_PAYDAY_TRUE,
+    DOMAIN,
     ICON_IS_IT_PAYDAY_FALSE,
+    ICON_IS_IT_PAYDAY_TRUE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -24,9 +24,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator: DataUpdateCoordinator = data["coordinator"]
     instance_name = data.get("name", "IsItPayday")
 
-    async_add_entities(
-        [IsItPaydaySensor(coordinator, entry.entry_id, instance_name)]
-    )
+    async_add_entities([IsItPaydaySensor(coordinator, entry.entry_id, instance_name)])
 
 
 class IsItPaydaySensor(CoordinatorEntity, BinarySensorEntity):

--- a/custom_components/isitpayday/calendar.py
+++ b/custom_components/isitpayday/calendar.py
@@ -7,12 +7,7 @@ from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
 )
 
-from .const import (
-    CONF_CONFIG_URL,
-    DOMAIN,
-    CONF_MANUFACTURER,
-    CONF_MODEL,
-)
+from .const import CONF_CONFIG_URL, CONF_MANUFACTURER, CONF_MODEL, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,9 +17,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
     coordinator: DataUpdateCoordinator = data["coordinator"]
     instance_name = data.get("name", "IsItPayday")
 
-    async_add_entities(
-        [IsItPaydayCalendar(coordinator, entry.entry_id, instance_name)]
-    )
+    async_add_entities([IsItPaydayCalendar(coordinator, entry.entry_id, instance_name)])
 
 
 class IsItPaydayCalendar(CoordinatorEntity, CalendarEntity):
@@ -106,4 +99,4 @@ class IsItPaydayCalendar(CoordinatorEntity, CalendarEntity):
             "manufacturer": CONF_MANUFACTURER,
             "model": CONF_MODEL,
             "configuration_url": CONF_CONFIG_URL,
-            }
+        }

--- a/custom_components/isitpayday/config_flow.py
+++ b/custom_components/isitpayday/config_flow.py
@@ -10,30 +10,30 @@ from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.selector import DateSelector, TimeSelector
 
 from .const import (
-    DOMAIN,
-    CONF_NAME,
-    CONF_COUNTRY,
-    CONF_PAY_FREQ,
-    CONF_PAY_DAY,
-    CONF_LAST_PAY_DATE,
     CONF_BANK_OFFSET,
-    CONF_WEEKDAY,
-    CONF_SUBDIV,
+    CONF_COUNTRY,
     CONF_EVENT_TIME,
+    CONF_LAST_PAY_DATE,
+    CONF_NAME,
+    CONF_PAY_DAY,
+    CONF_PAY_FREQ,
+    CONF_SUBDIV,
+    CONF_WEEKDAY,
     DEFAULT_COUNTRY,
     DEFAULT_EVENT_TIME,
-    PAY_FREQ_MONTHLY,
-    PAY_FREQ_BIMONTHLY,
-    PAY_FREQ_QUARTERLY,
-    PAY_FREQ_SEMIANNUAL,
-    PAY_FREQ_ANNUAL,
-    PAY_FREQ_28_DAYS,
-    PAY_FREQ_14_DAYS,
-    PAY_FREQ_WEEKLY,
-    PAY_FREQ_OPTIONS,
-    PAY_MONTHLY_OPTIONS,
+    DOMAIN,
     PAY_DAY_LAST_BANK_DAY,
     PAY_DAY_SPECIFIC_DAY,
+    PAY_FREQ_14_DAYS,
+    PAY_FREQ_28_DAYS,
+    PAY_FREQ_ANNUAL,
+    PAY_FREQ_BIMONTHLY,
+    PAY_FREQ_MONTHLY,
+    PAY_FREQ_OPTIONS,
+    PAY_FREQ_QUARTERLY,
+    PAY_FREQ_SEMIANNUAL,
+    PAY_FREQ_WEEKLY,
+    PAY_MONTHLY_OPTIONS,
     WEEKDAY_MAP,
     WEEKDAY_OPTIONS,
 )
@@ -88,11 +88,7 @@ class PaydayFlowMixin:
             return self.async_show_form(
                 step_id="event_time",
                 data_schema=vol.Schema(
-                    {
-                        vol.Required(
-                            CONF_EVENT_TIME, default=default
-                        ): TimeSelector()
-                    }
+                    {vol.Required(CONF_EVENT_TIME, default=default): TimeSelector()}
                 ),
             )
 
@@ -221,11 +217,7 @@ class PaydayFlowMixin:
             return self.async_show_form(
                 step_id="specific_day",
                 data_schema=vol.Schema(
-                    {
-                        vol.Required(CONF_PAY_DAY, default=default): vol.In(
-                            range(1, 32)
-                        )
-                    }
+                    {vol.Required(CONF_PAY_DAY, default=default): vol.In(range(1, 32))}
                 ),
             )
 
@@ -244,9 +236,7 @@ class PaydayFlowMixin:
                     }
                 )
             else:
-                schema = vol.Schema(
-                    {vol.Required(CONF_LAST_PAY_DATE): DateSelector()}
-                )
+                schema = vol.Schema({vol.Required(CONF_LAST_PAY_DATE): DateSelector()})
             return self.async_show_form(
                 step_id="cycle_last_paydate", data_schema=schema
             )
@@ -326,9 +316,9 @@ class IsItPaydayConfigFlow(PaydayFlowMixin, config_entries.ConfigFlow, domain=DO
                         vol.Required(CONF_NAME, default=""): vol.All(
                             str, vol.Length(min=1)
                         ),
-                        vol.Required(
-                            CONF_COUNTRY, default=default_country
-                        ): vol.In(self.country_list),
+                        vol.Required(CONF_COUNTRY, default=default_country): vol.In(
+                            self.country_list
+                        ),
                     }
                 ),
             )
@@ -380,17 +370,15 @@ class IsItPaydayOptionsFlow(PaydayFlowMixin, config_entries.OptionsFlow):
                 )
 
             default_country = (
-                self.country
-                if self.country in self.country_list
-                else DEFAULT_COUNTRY
+                self.country if self.country in self.country_list else DEFAULT_COUNTRY
             )
             return self.async_show_form(
                 step_id="init",
                 data_schema=vol.Schema(
                     {
-                        vol.Required(
-                            CONF_COUNTRY, default=default_country
-                        ): vol.In(self.country_list)
+                        vol.Required(CONF_COUNTRY, default=default_country): vol.In(
+                            self.country_list
+                        )
                     }
                 ),
             )

--- a/custom_components/isitpayday/diagnostics.py
+++ b/custom_components/isitpayday/diagnostics.py
@@ -6,7 +6,7 @@ from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN, CONF_NAME
+from .const import CONF_NAME, DOMAIN
 
 # The instance name may contain personal information (e.g. a person's name).
 TO_REDACT = {CONF_NAME}
@@ -36,11 +36,13 @@ async def async_get_config_entry_diagnostics(
             "options": async_redact_data(dict(entry.options), TO_REDACT),
         },
         "coordinator": {
-            "data": _serialize(dict(coordinator.data))
-            if coordinator and coordinator.data
-            else None,
-            "last_update_success": coordinator.last_update_success
-            if coordinator
-            else None,
+            "data": (
+                _serialize(dict(coordinator.data))
+                if coordinator and coordinator.data
+                else None
+            ),
+            "last_update_success": (
+                coordinator.last_update_success if coordinator else None
+            ),
         },
     }

--- a/custom_components/isitpayday/manifest.json
+++ b/custom_components/isitpayday/manifest.json
@@ -14,7 +14,7 @@
         "custom_components.isitpayday"
     ],
     "requirements": [
-        "holidays==0.94"
+        "holidays==0.99"
     ],
     "version": "5.0.0"
 }

--- a/custom_components/isitpayday/payday_calculator.py
+++ b/custom_components/isitpayday/payday_calculator.py
@@ -14,16 +14,16 @@ import holidays as holidays_lib
 from holidays.constants import BANK, OPTIONAL, PUBLIC
 
 from .const import (
-    PAY_FREQ_MONTHLY,
-    PAY_FREQ_28_DAYS,
+    PAY_DAY_FIRST_BANK_DAY,
+    PAY_DAY_LAST_BANK_DAY,
     PAY_FREQ_14_DAYS,
+    PAY_FREQ_28_DAYS,
+    PAY_FREQ_ANNUAL,
     PAY_FREQ_BIMONTHLY,
+    PAY_FREQ_MONTHLY,
     PAY_FREQ_QUARTERLY,
     PAY_FREQ_SEMIANNUAL,
-    PAY_FREQ_ANNUAL,
     PAY_FREQ_WEEKLY,
-    PAY_DAY_LAST_BANK_DAY,
-    PAY_DAY_FIRST_BANK_DAY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -118,16 +118,12 @@ def get_bank_holidays(country: str, years: list[int], subdiv: str | None = None)
             if extra in supported and extra not in categories:
                 categories.append(extra)
 
-        _LOGGER.debug(
-            "Using holiday categories %s for country %s", categories, country
-        )
+        _LOGGER.debug("Using holiday categories %s for country %s", categories, country)
         return holidays_lib.country_holidays(
             country, subdiv=subdiv, years=years, categories=tuple(categories)
         )
     except NotImplementedError:
-        _LOGGER.error(
-            "Country '%s' is not supported by the holidays package.", country
-        )
+        _LOGGER.error("Country '%s' is not supported by the holidays package.", country)
         return {}
     except Exception as e:
         _LOGGER.exception("Error generating holidays for %s: %s", country, e)
@@ -189,8 +185,14 @@ def calculate_next_payday(
 ):
     """Calculate the next payday date (first of the upcoming paydays)."""
     paydays = calculate_upcoming_paydays(
-        country, pay_frequency, pay_day, last_pay_date,
-        weekday, bank_offset, subdiv, count=1,
+        country,
+        pay_frequency,
+        pay_day,
+        last_pay_date,
+        weekday,
+        bank_offset,
+        subdiv,
+        count=1,
     )
     return paydays[0] if paydays else None
 
@@ -225,9 +227,7 @@ def calculate_last_payday(
     if pay_frequency == PAY_FREQ_MONTHLY:
         year, month = today.year, today.month
         for _ in range(24):
-            payday = _payday_for_month(
-                year, month, pay_day, bank_offset, bank_holidays
-            )
+            payday = _payday_for_month(year, month, pay_day, bank_offset, bank_holidays)
             if payday is not None and payday <= today:
                 return payday
             month -= 1
@@ -331,12 +331,15 @@ def calculate_upcoming_paydays(
     if pay_frequency == PAY_FREQ_MONTHLY:
         year, month = today.year, today.month
         for _ in range(count + 12):
-            payday = _payday_for_month(
-                year, month, pay_day, bank_offset, bank_holidays
-            )
-            if payday is None and not isinstance(pay_day, int) and pay_day not in (
-                PAY_DAY_LAST_BANK_DAY,
-                PAY_DAY_FIRST_BANK_DAY,
+            payday = _payday_for_month(year, month, pay_day, bank_offset, bank_holidays)
+            if (
+                payday is None
+                and not isinstance(pay_day, int)
+                and pay_day
+                not in (
+                    PAY_DAY_LAST_BANK_DAY,
+                    PAY_DAY_FIRST_BANK_DAY,
+                )
             ):
                 _LOGGER.error("Invalid payday value: %s", pay_day)
                 return []
@@ -452,9 +455,7 @@ def _find_first_bank_day(year: int, month: int, bank_holidays) -> date | None:
     return None
 
 
-def _find_specific_day(
-    year: int, month: int, day: int, bank_holidays
-) -> date | None:
+def _find_specific_day(year: int, month: int, day: int, bank_holidays) -> date | None:
     """Find a specific day of the month, adjusting backwards if not a bank day."""
     while day > 0:
         try:

--- a/custom_components/isitpayday/sensor.py
+++ b/custom_components/isitpayday/sensor.py
@@ -13,12 +13,12 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import (
     CONF_CONFIG_URL,
-    DOMAIN,
     CONF_MANUFACTURER,
     CONF_MODEL,
-    ICON_NEXT_PAYDAY,
+    DOMAIN,
     ICON_DAYS_TO,
     ICON_LAST_PAYDAY,
+    ICON_NEXT_PAYDAY,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -87,9 +87,7 @@ class IsItPaydayNextSensor(CoordinatorEntity, SensorEntity):
 
         upcoming_dates = [d for d in upcoming if isinstance(d, date)]
         this_month = [
-            d
-            for d in upcoming_dates
-            if d.year == today.year and d.month == today.month
+            d for d in upcoming_dates if d.year == today.year and d.month == today.month
         ]
 
         return {

--- a/tests/test_payday_calculator.py
+++ b/tests/test_payday_calculator.py
@@ -11,6 +11,7 @@ TODAY = date(2026, 6, 15)  # Monday, matches conftest FIXED_TODAY
 # Supported countries / subdivisions                                          #
 # --------------------------------------------------------------------------- #
 
+
 def test_supported_countries_readable_names(calc):
     countries = calc.get_supported_countries()
     assert countries["DK"] == "Denmark"
@@ -36,10 +37,11 @@ def test_subdivisions_empty_for_country_without_regions(calc):
 # Bank holidays / categories                                                  #
 # --------------------------------------------------------------------------- #
 
+
 def test_denmark_includes_optional_bank_closing_days(calc):
     holidays = calc.get_bank_holidays("DK", [2026])
     assert date(2026, 12, 24) in holidays  # Christmas Eve
-    assert date(2026, 6, 5) in holidays    # Constitution Day
+    assert date(2026, 6, 5) in holidays  # Constitution Day
 
 
 def test_unknown_country_returns_empty(calc):
@@ -57,13 +59,18 @@ def test_regional_holiday_only_with_subdivision(calc):
 # Upcoming paydays - monthly                                                   #
 # --------------------------------------------------------------------------- #
 
+
 def test_monthly_last_bank_day_returns_requested_count(calc):
-    paydays = calc.calculate_upcoming_paydays("DK", "monthly", "last_bank_day", count=12)
+    paydays = calc.calculate_upcoming_paydays(
+        "DK", "monthly", "last_bank_day", count=12
+    )
     assert len(paydays) == 12
 
 
 def test_upcoming_paydays_sorted_unique_and_future(calc):
-    paydays = calc.calculate_upcoming_paydays("DK", "monthly", "last_bank_day", count=12)
+    paydays = calc.calculate_upcoming_paydays(
+        "DK", "monthly", "last_bank_day", count=12
+    )
     assert paydays == sorted(set(paydays))
     assert all(p >= TODAY for p in paydays)
 
@@ -102,6 +109,7 @@ def test_monthly_invalid_pay_day_returns_empty(calc):
 # Upcoming paydays - interval & bimonthly                                      #
 # --------------------------------------------------------------------------- #
 
+
 def test_14_day_interval_is_stable(calc):
     paydays = calc.calculate_upcoming_paydays(
         "DK", "14_days", None, "2026-06-12", count=6
@@ -137,6 +145,7 @@ def test_other_intervals_return_requested_count(calc, freq):
 # Upcoming paydays - weekly                                                    #
 # --------------------------------------------------------------------------- #
 
+
 def test_weekly_returns_requested_count(calc):
     paydays = calc.calculate_upcoming_paydays("DK", "weekly", weekday=4, count=12)
     assert len(paydays) == 12
@@ -151,8 +160,11 @@ def test_weekly_without_weekday_raises(calc):
 # Count bounds & invalid frequency                                            #
 # --------------------------------------------------------------------------- #
 
+
 def test_count_capped_at_24(calc):
-    assert len(calc.calculate_upcoming_paydays("DK", "weekly", weekday=0, count=99)) == 24
+    assert (
+        len(calc.calculate_upcoming_paydays("DK", "weekly", weekday=0, count=99)) == 24
+    )
 
 
 def test_count_minimum_one(calc):
@@ -167,15 +179,19 @@ def test_invalid_frequency_returns_empty(calc):
 # next == first upcoming                                                       #
 # --------------------------------------------------------------------------- #
 
+
 def test_next_payday_equals_first_upcoming(calc):
     nxt = calc.calculate_next_payday("DK", "monthly", "last_bank_day")
-    first = calc.calculate_upcoming_paydays("DK", "monthly", "last_bank_day", count=1)[0]
+    first = calc.calculate_upcoming_paydays("DK", "monthly", "last_bank_day", count=1)[
+        0
+    ]
     assert nxt == first
 
 
 # --------------------------------------------------------------------------- #
 # Last payday                                                                  #
 # --------------------------------------------------------------------------- #
+
 
 def test_last_payday_monthly_is_on_or_before_today(calc):
     last = calc.calculate_last_payday("DK", "monthly", "last_bank_day")


### PR DESCRIPTION
I've been having issues with this component. 

Two other core components, `workday`: home-assistant/core#174501, `holiday`: https://github.com/home-assistant/core/pull/174501 were recently updated to `holidays==0.99`, so I propose this change.


The package difference is the only thing I could find.

The errors culminating for core components `workday` and `holiday` starting with this module import issue, implying different modules are having conflict in import:

```
Logger: homeassistant.util.loop
Source: util/loop.py:75
First occurred: 2:23:17 PM (1 occurrence)
Last logged: 2:23:17 PM

Detected blocking call to import_module with args ('homeassistant.components.holiday',) in /usr/src/homeassistant/homeassistant/loader.py, line 1091: ComponentProtocol, importlib.import_module(self.pkg_path) inside the event loop; This is causing stability issues. Please create a bug report at https://github.com/home-assistant/core/issues?q=is%3Aopen+is%3Aissue For developers, please see https://developers.home-assistant.io/docs/asyncio_blocking_operations/#import_module Traceback (most recent call last): File "<frozen runpy>", line 203, in _run_module_as_main File "<frozen runpy>", line 88, in _run_code File "/usr/src/homeassistant/homeassistant/__main__.py", line 227, in <module> sys.exit(main()) File "/usr/src/homeassistant/homeassistant/__main__.py", line 213, in main exit_code = runner.run(runtime_conf) File "/usr/src/homeassistant/homeassistant/runner.py", line 289, in run return loop.run_until_complete(setup_and_run_hass(runtime_config)) File "/usr/local/lib/python3.14/asyncio/base_events.py", line 706, in run_until_complete self.run_forever() File "/usr/local/lib/python3.14/asyncio/base_events.py", line 677, in run_forever self._run_once() File "/usr/local/lib/python3.14/asyncio/base_events.py", line 2056, in _run_once handle._run() File "/usr/local/lib/python3.14/asyncio/events.py", line 94, in _run self._context.run(self._callback, *self._args) File "/usr/src/homeassistant/homeassistant/setup.py", line 168, in async_setup_component result = await _async_setup_component(hass, domain, config) File "/usr/src/homeassistant/homeassistant/setup.py", line 341, in _async_setup_component component = await integration.async_get_component() File "/usr/src/homeassistant/homeassistant/loader.py", line 1043, in async_get_component comp = self._get_component() File "/usr/src/homeassistant/homeassistant/loader.py", line 1091, in _get_component ComponentProtocol, importlib.import_module(self.pkg_path)
```


Here's an example error that comes after the import issue, albeit the `workday` and `holiday` components aren't able to load, due to the import conflict.

```
This error originated from a custom integration.

Logger: custom_components.isitpayday.payday_calculator
Source: custom_components/isitpayday/payday_calculator.py:111
Integration: IsItPayday (documentation, issues)
First occurred: 2:23:41 PM (2 occurrences)
Last logged: 2:23:41 PM

Error generating holidays for US: module 'holidays' has no attribute 'country_holidays'
Traceback (most recent call last):
  File "/config/custom_components/isitpayday/payday_calculator.py", line 111, in get_bank_holidays
    probe = holidays_lib.country_holidays(country)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'holidays' has no attribute 'country_holidays'
```


